### PR TITLE
Refactor getOperator

### DIFF
--- a/src/Msisdn.php
+++ b/src/Msisdn.php
@@ -80,7 +80,7 @@ class Msisdn
      *
      * @return string The operator of this number
      */
-    function getOperator()
+    public function getOperator()
     {
         $this->setPrefixes();
 
@@ -90,20 +90,14 @@ class Msisdn
 
         if (in_array($this->getPrefix(), $this->smartPrefixes)) {
             $this->operator = 'SMART';
-            return $this->operator;
-        }
-
-        if (in_array($this->getPrefix(), $this->globePrefixes)) {
+        } else if (in_array($this->getPrefix(), $this->globePrefixes)) {
             $this->operator = 'GLOBE';
-            return $this->operator;
-        }
-
-        if (in_array($this->getPrefix(), $this->sunPrefixes)) {
+        } else if (in_array($this->getPrefix(), $this->sunPrefixes)) {
             $this->operator = 'SUN';
-            return $this->operator;
+        } else {
+            $this->operator = 'UNKNOWN';
         }
-
-        $this->operator = 'UNKNOWN';
+        
         return $this->operator;
     }
 


### PR DESCRIPTION
- Add explicit accessibility.
- Refactor `operator` prop assignment to avoid multiple `return` keyword.
